### PR TITLE
Add copy to clipboard button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .DS_Store
 bower_components/
 coverage-reports/
+
+*.iml
+

--- a/code-sample.html
+++ b/code-sample.html
@@ -62,7 +62,9 @@
     <slot id="content"></slot>
 
     <div id="code-container">
-      <button id="copy-button" title="Copy to clipboard" on-click="_copyToClipboard">Copy</button>
+      <template is="dom-if" if="[[copyClipboardButton]]">
+        <button id="copy-button" title="Copy to clipboard" on-click="_copyToClipboard">Copy</button>
+      </template>
       <pre id="code"></pre>
     </div>
   </template>
@@ -83,6 +85,10 @@
 
       static get properties() {
         return {
+          copyClipboardButton: {
+            type: Boolean,
+            value: false
+          },
           /**
            * Set to true to render the code inside the template.
            */

--- a/code-sample.html
+++ b/code-sample.html
@@ -5,10 +5,18 @@
 <dom-module id="code-sample">
   <template>
     <style include="code-sample-theme">
-      :host { display: block; }
-      :host([hidden]) { display: none; }
+      :host {
+        display: block;
+      }
 
-      pre { margin: 0; }
+      :host([hidden]) {
+        display: none;
+      }
+
+      pre {
+        margin: 0;
+      }
+
       pre, code {
         font-family: var(--code-sample-font-family, Operator Mono, Inconsolata, Roboto Mono, monaco, consolas, monospace);
         font-size: var(--code-sample-font-size, 14px);
@@ -26,11 +34,37 @@
       .demo {
         @apply --code-sample-demo;
       }
+
+      #code-container {
+        position: relative;
+      }
+
+      #code-container:hover > button {
+        display: block;
+      }
+
+      button {
+        background: #e0e0e0;
+        border: none;
+        cursor: pointer;
+        display: none;
+        position: absolute;
+        right: 0;
+        top: 0;
+        text-transform: uppercase;
+
+        @apply --code-sample-copy-clipboard-button;
+      }
     </style>
 
     <div id="demo" class="demo"></div>
+
     <slot id="content"></slot>
-    <pre id="code"></pre>
+
+    <div id="code-container">
+      <button id="copy-button" title="Copy to clipboard" on-click="_copyToClipboard">Copy</button>
+      <pre id="code"></pre>
+    </div>
   </template>
   <script>
     /* global hljs */
@@ -94,8 +128,7 @@
           this.$.demo.innerHTML = '';
         }
 
-        let nodes = Polymer.FlattenedNodesObserver.getFlattenedNodes(this.$.content);
-        let template = [].filter.call(nodes, (node) => node.nodeType === Node.ELEMENT_NODE)[0];
+        let template = this._getCodeTemplate();
 
         if (this.render) {
           this._demo = this.$.demo.appendChild(document.importNode(template.content, true));
@@ -122,6 +155,41 @@
       _entitize(str) {
         return String(str).replace(/=""/g, '').replace(/=&gt;/g, '=>').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
       }
+
+      _getCodeTemplate() {
+        let nodes = Polymer.FlattenedNodesObserver.getFlattenedNodes(this.$.content);
+        return [].filter.call(nodes, (node) => node.nodeType === Node.ELEMENT_NODE)[0];
+      }
+
+      _copyToClipboard() {
+        let tempNode = document.createElement('input');
+        document.body.appendChild(tempNode);
+        tempNode.value = this._getCodeTemplate().innerHTML;
+        tempNode.select();
+
+        let result = false;
+
+        try {
+          result = document.execCommand('copy', false);
+          this.$['copy-button'].textContent = 'Done';
+        } catch (err) {
+          // Copy command is not available
+          console.error(err);
+          this.$['copy-button'].textContent = 'Error';
+        }
+
+        tempNode.remove();
+
+        // Return to the copy button after a second.
+        setTimeout(this._resetCopyButtonState.bind(this), 1000);
+
+        return result;
+      }
+
+      _resetCopyButtonState() {
+        this.$['copy-button'].textContent = 'Copy';
+      }
+
     }
 
     customElements.define(CodeSample.is, CodeSample);

--- a/code-sample.html
+++ b/code-sample.html
@@ -176,20 +176,22 @@
       }
 
       _copyToClipboard() {
-        let tempNode = document.createElement('input');
+        let tempNode = document.createElement('textarea');
         document.body.appendChild(tempNode);
         tempNode.value = this._getCodeTemplate().innerHTML;
         tempNode.select();
 
         let result = false;
 
+        let copyButton = this.shadowRoot.querySelector("#copy-button");
+
         try {
           result = document.execCommand('copy', false);
-          this.$['copy-button'].textContent = 'Done';
+          copyButton.textContent = 'Done';
         } catch (err) {
           // Copy command is not available
           console.error(err);
-          this.$['copy-button'].textContent = 'Error';
+          copyButton.textContent = 'Error';
         }
 
         tempNode.remove();
@@ -201,7 +203,7 @@
       }
 
       _resetCopyButtonState() {
-        this.$['copy-button'].textContent = 'Copy';
+        this.shadowRoot.querySelector("#copy-button").textContent = 'Copy';
       }
 
     }

--- a/code-sample.html
+++ b/code-sample.html
@@ -37,17 +37,25 @@
 
       #code-container {
         position: relative;
+
+        @apply --code-sample-code-container;
+      }
+
+      #code-container:hover {
+        @apply --code-sample-code-container-hover;
       }
 
       #code-container:hover > button {
         display: block;
+
+        @apply --code-sample-code-container-hover-button;
       }
 
       button {
         background: #e0e0e0;
         border: none;
         cursor: pointer;
-        display: none;
+        display: block;
         position: absolute;
         right: 0;
         top: 0;


### PR DESCRIPTION
This is a quick patch for kcmr/code-sample#3.

The button style is customisable by using the new CSS mixin `--code-sample-copy-clipboard-button`.